### PR TITLE
Pin jmeter openjdk dependency to JDK17

### DIFF
--- a/Formula/jmeter.rb
+++ b/Formula/jmeter.rb
@@ -10,7 +10,7 @@ class Jmeter < Formula
     sha256 cellar: :any_skip_relocation, all: "ad4c2d2fd4fe481f9443824e6555240d68b26bd01a7ce8444f755fe20f32e51e"
   end
 
-  depends_on "openjdk"
+  depends_on "openjdk@17"
 
   resource "jmeter-plugins-manager" do
     url "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/1.7/jmeter-plugins-manager-1.7.jar"
@@ -22,7 +22,7 @@ class Jmeter < Formula
     rm_f Dir["bin/*.bat"]
     prefix.install_metafiles
     libexec.install Dir["*"]
-    (bin/"jmeter").write_env_script libexec/"bin/jmeter", JAVA_HOME: Formula["openjdk"].opt_prefix
+    (bin/"jmeter").write_env_script libexec/"bin/jmeter", JAVA_HOME: Formula["openjdk@17"].opt_prefix
 
     resource("jmeter-plugins-manager").stage do
       (libexec/"lib/ext").install Dir["*"]


### PR DESCRIPTION
This change pins openjdk@17 since newer versions of the JDK are not fully supported by JMeter.

Reference:
The current version of JMeter is tested only to JDK17 see notes from apache [here](https://jmeter.apache.org/changes.html#New%20and%20Noteworthy) 

One of its plugins, Groovy, does not support >JDK17 and throws a runtime exception when compiling scripts. See Groovy notes [here](https://groovy-lang.org/releasenotes/groovy-4.0.html#Groovy4.0-requirements)



<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
